### PR TITLE
Prevent override of gmap gestureHandling setting

### DIFF
--- a/src/GMapView.js
+++ b/src/GMapView.js
@@ -72,7 +72,7 @@ const GMapView = {
     )
 
     gmap.setOptions({
-      gestureHandling: gmapModel.get('roam') ? 'auto' : 'none'
+      gestureHandling: gmapModel.get('roam') ? (gmapModel.get('gestureHandling') ?? 'auto') : 'none'
     })
 
     rendering = false


### PR DESCRIPTION
Fixes #19 

This pr adds the smalles possible change to fix #19, allowing to use the google maps `gestureHandling` setting in the extension configuration object. I've tested the proposed changes with my application.

It also shouldn't break existing behaviour as shown in the following table (3 behaviour changes marked bold):

| `roam`         | `gestureHandling` | old behaviour                 | new behaviour                        |
|----------------|-------------------|-------------------------------|--------------------------------------|
| true (default) | "cooperative"     | gestureHandling set to "auto" | **gestureHandling set to "cooperative"** |
| true (default) | "greedy"          | gestureHandling set to "auto" | **gestureHandling set to "greedy"**      |
| true (default) | "none"            | gestureHandling set to "auto" | **gestureHandling set to "none"**        |
| true (default) | "auto"            | gestureHandling set to "auto" | gestureHandling set to "auto"        |
| true (default) | undefined         | gestureHandling set to "auto" | gestureHandling set to "auto"        |
| false          | "cooperative"     | gestureHandling set to "none" | gestureHandling set to "none"        |
| false          | "greedy"          | gestureHandling set to "none" | gestureHandling set to "none"        |
| false          | "none"            | gestureHandling set to "none" | gestureHandling set to "none"        |
| false          | "auto"            | gestureHandling set to "none" | gestureHandling set to "none"        |
| false          | undefined         | gestureHandling set to "none" | gestureHandling set to "none"        |

Happy to receive your review @plainheart 😊 
And btw, thanks for the great extension! 🙌 